### PR TITLE
track inerted elements (fixes #2)

### DIFF
--- a/blocking-elements.js
+++ b/blocking-elements.js
@@ -26,7 +26,7 @@
   const _setInertToSiblingsOfElement = Symbol();
   const _getParents = Symbol();
   const _getDistributedChildren = Symbol();
-  const _isInertable = Symbol();
+  const _isNotInertable = Symbol();
   const _isInert = Symbol();
   const _setInert = Symbol();
 
@@ -178,8 +178,8 @@
      * @returns {boolean}
      * @private
      */
-    static[_isInertable](element) {
-      return /^(style|template|script)$/.test(element.localName);
+    static[_isNotInertable](element) {
+      return /^(style|template|script|content|slot)$/.test(element.localName);
     }
 
     /**
@@ -198,7 +198,7 @@
       let sibling = element;
       while ((sibling = sibling.previousElementSibling)) {
         // If not inertable or to be skipped, skip.
-        if (this[_isInertable](sibling) || (elemsToSkip && elemsToSkip.has(sibling))) {
+        if (this[_isNotInertable](sibling) || (elemsToSkip && elemsToSkip.has(sibling))) {
           continue;
         }
         // Should be collected since already inerted.
@@ -212,7 +212,7 @@
       sibling = element;
       while ((sibling = sibling.nextElementSibling)) {
         // If not inertable or to be skipped, skip.
-        if (this[_isInertable](sibling) || (elemsToSkip && elemsToSkip.has(sibling))) {
+        if (this[_isNotInertable](sibling) || (elemsToSkip && elemsToSkip.has(sibling))) {
           continue;
         }
         // Should be collected since already inerted.

--- a/blocking-elements.js
+++ b/blocking-elements.js
@@ -131,9 +131,8 @@
      * for common parents and avoid setting them twice).
      * When the first blocking element is added (`newTop = null`), it saves the elements
      * that are already inert into `alreadyInertElems`. When the last blocking element
-     * is removed (`oldTop = null`), `alreadyInertElems` are kept inert.
+     * is removed, `alreadyInertElems` are kept inert.
      * @param {HTMLElement} newTop If null, it means the last blocking element was removed.
-     * @param {HTMLElement} oldTop If null, it means the first blocking element was added.
      * @param {!Set<HTMLElement>} alreadyInertElems Elements to be kept inert.
      * @private
      */
@@ -152,6 +151,7 @@
       }
       // Same parent, just switch old & new inertness.
       if (i >= 0 && j >= 0 && oldParents[i + 1] === parents[j + 1]) {
+        //TODO(valdrin) update __inertedSiblings!
         this[_setInert](oldParents[i], true);
         this[_setInert](parents[j], alreadyInertElems.has(parents[j]));
         i--;
@@ -192,13 +192,11 @@
 
     /**
      * Sets `inert` to the siblings of the element except the elements to skip.
-     * If `inert = true`, already inert elements are added into `alreadyInertElems`.
-     * If `inert = false`, siblings that are contained in `alreadyInertElems` will
-     * be kept inert.
+     * be kept inert. Returns the inerted siblings.
      * @param {!HTMLElement} element
-     * @param {boolean} inert
      * @param {Set<HTMLElement>} elemsToSkip
      * @param {Set<HTMLElement>} alreadyInertElems
+     * @returns {Array<HTMLElement>}
      * @private
      */
     static[_setInertToSiblingsOfElement](element, elemsToSkip, alreadyInertElems) {

--- a/blocking-elements.js
+++ b/blocking-elements.js
@@ -270,22 +270,22 @@
      * @private
      */
     [_getParents](element) {
-      const newParents = [];
+      const parents = [];
       let current = element;
       // Stop to body.
       while (current && current !== document.body) {
         // Skip shadow roots.
         if (current.nodeType === Node.ELEMENT_NODE) {
-          newParents.push(current);
+          parents.push(current);
         }
         // ShadowDom v1
         if (current.assignedSlot) {
           // Collect slots from deepest slot to top.
           while ((current = current.assignedSlot)) {
-            newParents.push(current);
+            parents.push(current);
           }
           // Continue the search on the top slot.
-          current = newParents.pop();
+          current = parents.pop();
           continue;
         }
         // ShadowDom v0
@@ -293,15 +293,15 @@
           current.getDestinationInsertionPoints() : [];
         if (insertionPoints.length) {
           for (let i = 0; i < insertionPoints.length; i++) {
-            newParents.push(insertionPoints[i]);
+            parents.push(insertionPoints[i]);
           }
           // Continue the search on the top content.
-          current = newParents.pop();
+          current = parents.pop();
           continue;
         }
         current = current.parentNode || current.host;
       }
-      return newParents;
+      return parents;
     }
 
     /**

--- a/blocking-elements.js
+++ b/blocking-elements.js
@@ -151,7 +151,14 @@
       }
       // Same parent, just switch old & new inertness.
       if (i >= 0 && j >= 0 && oldParents[i + 1] === parents[j + 1]) {
-        //TODO(valdrin) update __inertedSiblings!
+        // Update siblings array.
+        const parentSiblings = oldParents[i + 1].__inertedSiblings;
+        if (!alreadyInertElems.has(oldParents[i])) {
+          parentSiblings.push(oldParents[i]);
+        }
+        const idx = parentSiblings.indexOf(parents[j]);
+        idx >= 0 && parentSiblings.splice(idx, 1);
+        // Flip inertness.
         this[_setInert](oldParents[i], true);
         this[_setInert](parents[j], alreadyInertElems.has(parents[j]));
         i--;
@@ -259,6 +266,7 @@
         }
         current = current.parentNode || current.host;
       }
+      parents.push(document.body);
       return parents;
     }
 

--- a/demo/ce.html
+++ b/demo/ce.html
@@ -62,6 +62,12 @@ limitations under the License.
     <input placeholder="in body">
     <x-trap-focus id="nested-inner">
       <input placeholder="in body">
+      <x-trap-focus id="nested-inner-inner">
+        <input placeholder="in body">
+      </x-trap-focus>
+    </x-trap-focus>
+    <x-trap-focus id="nested-inner2">
+      <input placeholder="in body">
     </x-trap-focus>
   </x-trap-focus>
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -123,6 +123,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.isTrue(container.children[2].inert, '3rd child inert');
       });
 
+      test('remove() handles elements not in the dom anymore', function() {
+        document.$blockingElements.push(container.children[0]);
+        assert.equal(document.$blockingElements.top, container.children[0]);
+        container.removeChild(container.children[0]);
+        document.$blockingElements.remove(container.children[0]);
+        assert.equal(document.$blockingElements.top, null);
+        assert.isNotOk(container.inert, 'container active');
+        assert.isNotOk(container.children[1].inert, '2nd child active');
+        assert.isNotOk(container.children[2].inert, '3rd child active');
+      });
+
     });
 
     suite('nested', function() {

--- a/test/basic.html
+++ b/test/basic.html
@@ -137,6 +137,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       });
 
+      test('destructor resets the document inertness', function() {
+        document.$blockingElements.push(container.children[0]);
+        // Destroy and then construct again.
+        document.$blockingElements.destructor();
+        document.$blockingElements = new document.$blockingElements.constructor();
+        assert.isNotOk(container.inert, 'container active');
+        // Remaining children should be active.
+        for (let i = 0; i < container.children.length; i++) {
+          assert.isNotOk(container.children[i].inert, 'sibling active');
+        }
+      });
+
     });
 
     suite('nested', function() {

--- a/test/basic.html
+++ b/test/basic.html
@@ -124,14 +124,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('remove() handles elements not in the dom anymore', function() {
-        document.$blockingElements.push(container.children[0]);
-        assert.equal(document.$blockingElements.top, container.children[0]);
-        container.removeChild(container.children[0]);
-        document.$blockingElements.remove(container.children[0]);
+        const child = container.children[0];
+        document.$blockingElements.push(child);
+        assert.equal(document.$blockingElements.top, child);
+        container.removeChild(child);
+        document.$blockingElements.remove(child);
         assert.equal(document.$blockingElements.top, null);
         assert.isNotOk(container.inert, 'container active');
-        assert.isNotOk(container.children[1].inert, '2nd child active');
-        assert.isNotOk(container.children[2].inert, '3rd child active');
+        // Remaining children should be active.
+        for (let i = 0; i < container.children.length; i++) {
+          assert.isNotOk(container.children[i].inert, 'sibling active');
+        }
       });
 
     });


### PR DESCRIPTION
Fixes #2 by keeping track of the elements we inert, and restore them to their original inertness.

This approach is not bullet-proof, as users might modify the dom tree by adding/removing elements. The new structure of the class should allow to expose a method to help with these cases by requiring the user to call it, something like:
```javascript
// after modifications to the dom are done
document.$blockingElements.refresh();

// implementation of refresh:
refresh() {
  // Restores original inertness.
  this[_topChanged](null); 
  // Computes again the inerted siblings & parents
  this.top && this[_topChanged](this.top);
}
```
^ This should be done in a separate PR.
