### PR TITLE
Bring to top

### DIFF
--- a/test/basic.html
+++ b/test/basic.html
@@ -84,6 +84,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(document.$blockingElements.top, null);
       });
 
+      test('push() can be used to make an already blocking element the top blocking element', function() {
+        assert.equal(document.$blockingElements.top, null);
+        document.$blockingElements.push(container.children[0]);
+        assert.equal(document.$blockingElements.top, container.children[0], 'child0 is top blocking element');
+        // Add another element.
+        document.$blockingElements.push(container.children[1]);
+        assert.equal(document.$blockingElements.top, container.children[1], 'child1 is top blocking element');
+        // Push again first element.
+        document.$blockingElements.push(container.children[0]);
+        assert.equal(document.$blockingElements.top, container.children[0], 'child0 brought to top');
+      });
+
+      test('push() adds only elements contained in document', function() {
+        assert.equal(document.$blockingElements.top, null);
+        assert.throws(function() {
+          document.$blockingElements.push(document.createElement('div'));
+        }, 'Non-connected element cannot be a blocking element');
+        assert.equal(document.$blockingElements.top, null, 'element is not a blocking element');
+      });
+
       test('pop() removes the top blocking element from stack and returns it', function() {
         document.$blockingElements.push(container.children[0]);
         document.$blockingElements.push(container.children[1]);

--- a/test/shadow.html
+++ b/test/shadow.html
@@ -96,6 +96,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.isNotOk(container.children[2].inert, '3rd child inert restored');
       });
 
+      test('push() adds only elements contained in document', function() {
+        assert.equal(document.$blockingElements.top, null);
+        // We remove the container, then we try to add one of its shadowRoot children.
+        container.parentNode.removeChild(container);
+        assert.throws(function() {
+          document.$blockingElements.push(container.shadowRoot.firstElementChild);
+        }, 'Non-connected element cannot be a blocking element');
+        assert.equal(document.$blockingElements.top, null, 'element is not a blocking element');
+      });
+
     });
 
     suite('ShadowDom v1', function() {
@@ -143,6 +153,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.isNotOk(container.children[0].inert, '1st child inert restored');
         assert.isNotOk(container.children[1].inert, '2nd child inert restored');
         assert.isNotOk(container.children[2].inert, '3rd child inert restored');
+      });
+
+      test('push() adds only elements contained in document', function() {
+        assert.equal(document.$blockingElements.top, null);
+        // We remove the container, then we try to add one of its shadowRoot children.
+        container.parentNode.removeChild(container);
+        assert.throws(function() {
+          document.$blockingElements.push(container.shadowRoot.firstElementChild);
+        }, 'Non-connected element cannot be a blocking element');
+        assert.equal(document.$blockingElements.top, null, 'element is not a blocking element');
       });
 
     });


### PR DESCRIPTION
Fixes #5 by checking if element is defined and attached to the document.
Also, instead of warning that the element is already a blocking element, it brings it to the top.
